### PR TITLE
Fix potential KVO crash when initialize is called multiple times

### DIFF
--- a/MXParallaxHeader/MXScrollView.m
+++ b/MXParallaxHeader/MXScrollView.m
@@ -34,6 +34,7 @@
 @implementation MXScrollView {
     BOOL _isObserving;
     BOOL _lock;
+    dispatch_once_t _onceToken;
 }
 
 static void * const kMXScrollViewKVOContext = (void*)&kMXScrollViewKVOContext;
@@ -66,15 +67,17 @@ static void * const kMXScrollViewKVOContext = (void*)&kMXScrollViewKVOContext;
 }
 
 - (void) initialize {
-    super.delegate = self.delegateForwarder;
-    self.showsVerticalScrollIndicator = NO;
-    self.directionalLockEnabled = YES;
-    self.bounces = YES;
-    
-    [self addObserver:self forKeyPath:NSStringFromSelector(@selector(contentOffset))
-              options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld
-              context:kMXScrollViewKVOContext];
-    _isObserving = YES;
+    dispatch_once(&_onceToken, ^{
+        super.delegate = self.delegateForwarder;
+        self.showsVerticalScrollIndicator = NO;
+        self.directionalLockEnabled = YES;
+        self.bounces = YES;
+
+        [self addObserver:self forKeyPath:NSStringFromSelector(@selector(contentOffset))
+                  options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld
+                  context:kMXScrollViewKVOContext];
+        _isObserving = YES;
+    });
 }
 
 #pragma mark Properties


### PR DESCRIPTION
Since today (with no related code change that I'm aware of) I'm experiencing the following crash with MXSegmentedPager: 

When leaving a view where MXSegmentedPager is used, the app crashes with the following exception: 

> Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'An instance 0x7a352a00 of class MXScrollView was deallocated while key value observers were still registered with it. Current observation info: <NSKeyValueObservationInfo 0x7c05b470>

I was really confused, because I can clearly see that `MXScrollView` does remove itself as an KVO observer in its dealloc method: 

``` objc
- (void)dealloc {
    [self removeObserver:self forKeyPath:NSStringFromSelector(@selector(contentOffset)) context:kMXScrollViewKVOContext];
    [self removeObservedViews];
}
```

After some time, I found that `[MXScrollView initialize]` was somehow called twice. I'm still not sure how that is happening, but that lead to 

```
[self addObserver:self forKeyPath:NSStringFromSelector(@selector(contentOffset))
                  options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld
                  context:kMXScrollViewKVOContext];
```

being called twice. 

As soon as I called `[self removeObserver:self forKeyPath:NSStringFromSelector(@selector(contentOffset)) context:kMXScrollViewKVOContext];` twice in the dealloc method, the crashes stopped. 

Is this even possible? I'm confused 😕 
### Fix

Even though its well possible that the root of this specific bug is in my code, I thought it might still be a good idea to make sure that `[MXScrollView initialize]` is only called once.
