### PR TITLE
Fixed conflict between scrollViews

### DIFF
--- a/MXParallaxHeader/MXScrollView.m
+++ b/MXParallaxHeader/MXScrollView.m
@@ -161,7 +161,7 @@ static void * const kMXScrollViewKVOContext = (void*)&kMXScrollViewKVOContext;
         if (object == self) {
             
             //Adjust self scroll offset when scroll down
-            if (diff > 0 && _lock) {
+            if (diff > 0 && _lock && old.y <= -self.parallaxHeader.minimumHeight) {
                 [self scrollView:self setContentOffset:old];
             }
             else if (((self.contentOffset.y < -self.contentInset.top) && !self.bounces)) {


### PR DESCRIPTION
Fixed the problem when start to scroll up the tableView a little bit and then stop, then if start the scroll down with the touch at header nothing happens.
