### PR TITLE
MXScrollView setContentOffset not work

### DIFF
--- a/MXParallaxHeader/MXScrollView.m
+++ b/MXParallaxHeader/MXScrollView.m
@@ -206,6 +206,7 @@ static void * const kMXScrollViewKVOContext = (void*)&kMXScrollViewKVOContext;
 }
 
 - (void)scrollView:(UIScrollView *)scrollView setContentOffset:(CGPoint)offset {
+    _lock = NO;
     _isObserving = NO;
     scrollView.contentOffset = offset;
     _isObserving = YES;


### PR DESCRIPTION
When scrolling up MXScrollView, _lock is set to YES
At this time, if I try to set the scroll position of MXScrollView with setContentOffset, the scroll position can not be changed. For example, I want to tap a table cell and want to return to the initial scroll position.
