### PR TITLE
Fixed top inset on iOS 11 (parallax view was going under the nav bar)

### DIFF
--- a/MXParallaxHeader/MXParallaxHeader.m
+++ b/MXParallaxHeader/MXParallaxHeader.m
@@ -214,7 +214,13 @@ static void * const kMXParallaxHeaderKVOContext = (void*)&kMXParallaxHeaderKVOCo
 
 - (void)layoutContentView {
     CGFloat minimumHeight = MIN(self.minimumHeight, self.height);
-    CGFloat relativeYOffset = self.scrollView.contentOffset.y + self.scrollView.contentInset.top - self.height;
+    CGFloat topInset;
+    if (@available(iOS 11.0, *)) {
+        topInset = self.scrollView.adjustedContentInset.top;
+    } else {
+        topInset = self.scrollView.contentInset.top;
+    }
+    CGFloat relativeYOffset = self.scrollView.contentOffset.y + topInset - self.height;
     CGFloat relativeHeight  = -relativeYOffset;
     
     CGRect frame = (CGRect){


### PR DESCRIPTION
Fixed by using the new `UIScrollView.adjustedContentInset` when running on iOS 11. This fix requires Xcode 9 to compile.