### PR TITLE
Set public headers to make all .h files public

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .target(
             name: "MXParallaxHeader",
             dependencies: [],
-            path: "Sources")
+            path: "Sources",
+            publicHeadersPath: ".")
     ]
 )


### PR DESCRIPTION
## Description
Export headers for SPM pakcage

## Motivation and Context
Make header public (otherwise all class are in the module, and not exposed)

## How Has This Been Tested?
Created a single view storyboard project, and added https://github.com/openium/MXParallaxHeader in Swift Packages of Xcode, then :

```diff
git diff TestMXP/ViewController.swift
diff --git a/TestMXP/ViewController.swift b/TestMXP/ViewController.swift
index f3c8b3b..754cdd0 100644
--- a/TestMXP/ViewController.swift
+++ b/TestMXP/ViewController.swift
@@ -7,12 +7,19 @@
 //

 import UIKit
+import MXParallaxHeader

 class ViewController: UIViewController {

     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+
+        let header = MXParallaxHeader()
+
+        let scrollView = UIScrollView()
+        scrollView.parallaxHeader = header
+
+        view.addSubview(scrollView)
     }
```

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.