### PR TITLE
Fix SPM Usage in Xcode 12.5+

### DIFF
--- a/Sources/MXParallaxHeader.h
+++ b/Sources/MXParallaxHeader.h
@@ -21,6 +21,8 @@
 // THE SOFTWARE.
 
 #import <UIKit/UIKit.h>
+#import "MXScrollView.h"
+#import "MXScrollViewController.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/MXScrollViewController.h
+++ b/Sources/MXScrollViewController.h
@@ -22,6 +22,9 @@
 
 #import "MXScrollView.h"
 
+@class MXParallaxHeader;
+@class MXScrollView;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**


### PR DESCRIPTION
## Description

On Xcode 12.5, apparently the umbrella header generation logic changed, so this stopped working on my project because my project couldn't find `MXScrollView` anymore, when importing this lib using SPM. The problem was that the generated umbrella header didn't contain references to all the public headers. This PR aims to fix that.

## Motivation and Context

## How Has This Been Tested?
It compiles on my project now 😄 

Before:

```
import MXParallaxHeader
…
let scrollView = MXScrollView // Couldn't find reference to MXScrollView
```

Now, the same code above compiles just fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. - Nope
- [ ] I have updated the documentation accordingly. - There's no need to update anything